### PR TITLE
Fix/material gap

### DIFF
--- a/lib/src/casa_vertical_stepper_view.dart
+++ b/lib/src/casa_vertical_stepper_view.dart
@@ -14,6 +14,7 @@ class CasaVerticalStepperView extends StatefulWidget {
   final bool isExpandable;
   final bool showStepStatusWidget;
   final ScrollPhysics? physics;
+
   const CasaVerticalStepperView({
     required this.steps,
     this.seperatorColor,
@@ -116,11 +117,12 @@ class _CasaVerticalStepperViewState extends State<CasaVerticalStepperView> {
       child: Row(
         children: <Widget>[
           _buildIcon(step),
-          Container(
-            margin: const EdgeInsetsDirectional.only(start: _kStepSpacing),
-            child: step.title,
+          Flexible(
+            child: Container(
+              margin: const EdgeInsetsDirectional.only(start: _kStepSpacing),
+              child: step.title,
+            ),
           ),
-          const Spacer(),
           step.trailing ?? const SizedBox(height: 0, width: 0)
         ],
       ),

--- a/lib/src/casa_vertical_stepper_view.dart
+++ b/lib/src/casa_vertical_stepper_view.dart
@@ -50,7 +50,7 @@ class _CasaVerticalStepperViewState extends State<CasaVerticalStepperView> {
   }
 
   Widget _buildVertical() {
-    return widget.isExpandable
+    return widget.isExpandable && steps.isNotEmpty
         ? _buildPanel()
         : ListView(
             shrinkWrap: true,


### PR DESCRIPTION
Fix error when there is no content on init state.

Consider calling Widget classes instead of Widget functions inside a build method, to prevent reloading data. It also improves app performance.

<img width="632" alt="Screen Shot 2023-01-14 at 13 27 14" src="https://user-images.githubusercontent.com/42304227/212483403-c93e8332-e79b-4018-b2c0-aa7c8a6a0e35.png">

Update 1 -->
Check this branch if you want to pull request and merge performance improvement changes. https://github.com/nekomaruh/casa_vertical_stepper/tree/feature/code-enhancement
